### PR TITLE
moves samples to examples/ dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ libbpf-sys = { version = "0.0.7-1" }
 libc = "0.2"
 errno = "0.2"
 arraydeque = "0.4"
-crossbeam-channel = "0.4"
-rlimit = "0.3"
-structopt = "0.3"
 
 [dev-dependencies]
 criterion = "0.3"
+structopt = "0.3"
+rlimit = "0.3"
+crossbeam-channel = "0.4"
 
 [[bench]]
 name = "bufpool"

--- a/README.md
+++ b/README.md
@@ -25,11 +25,16 @@ If you have knowledge of Rust FFI and general Rust unsafe things I would greatly
 
 ## Sample Programs
 
-There are two sample programs in src/bin/:
+There are two sample programs in `examples/`:
 
-l2fwd-1link: Receives frames on a single link/queue, swaps the MAC and writes back to the same link/queue. This is roughly like the kernel xdpsock_user.c sample program in l2fwd mode.
+* `l2fwd-1link`: Receives frames on a single link/queue, swaps the MAC and
+  writes back to the same link/queue. This is roughly like the kernel
+  xdpsock_user.c sample program in l2fwd mode.
+* `l2fwd-2link`: Receives frames from two link/queue pairs (separate devices)
+  and forwards the frames to the opposite link.
 
-l2fwd-2link: Receives frames from two link/queue pairs (separate devices) and forwards the frames to the opposite link.
+You can run with `cargo run --release --example <example_name> -- [example options]` to
+see a list of options run `cargo run --release --example <example_name> -- --help`
 
 ## Performance
 

--- a/examples/l2fwd-1link.rs
+++ b/examples/l2fwd-1link.rs
@@ -71,38 +71,41 @@ struct BufCustom {}
 #[derive(StructOpt, Debug)]
 #[structopt(name = "l2fwd-1link")]
 struct Opt {
+    /// Default buffer size
     #[structopt(long, default_value = "4096")]
     bufsize: usize,
 
+    /// How many buffers
     #[structopt(long, default_value = "4096")]
     bufnum: usize,
 
+    /// Batch size
     #[structopt(long, default_value = "64")]
     batch_size: usize,
 
-    #[structopt(long, default_value = "none")]
+    /// The link to attach to
+    #[structopt(long)]
     link_name: std::string::String,
 
+    /// Link channel
     #[structopt(long, default_value = "0")]
     link_channel: usize,
 
+    /// Use HUGE TLB
     #[structopt(long)]
     huge_tlb: bool,
 
+    /// Use zero copy mode
     #[structopt(long)]
     zero_copy: bool,
 
-    #[structopt(long)]
+    /// Copy mode
+    #[structopt(long, conflicts_with = "zero-copy")]
     copy: bool,
 }
 
 fn main() {
     let opt = Opt::from_args();
-
-    if opt.link_name == "none" {
-        println!("Link name parameter is required");
-        return;
-    }
 
     assert!(setrlimit(Resource::MEMLOCK, RLIM_INFINITY, RLIM_INFINITY).is_ok());
 
@@ -145,8 +148,8 @@ fn main() {
         Err(err) => panic!("no socket for you: {:?}", err),
     };
 
-    // Create a local buf pool and get bufs from the global pool. Since there are no other users of the pool, grab
-    // all the bufs.
+    // Create a local buf pool and get bufs from the global pool. Since there
+    // are no other users of the pool, grab all the bufs.
     let mut bufs: Vec<Buf<BufCustom>> = Vec::with_capacity(opt.bufnum);
     let r = buf_pool.lock().unwrap().get(&mut bufs, opt.bufnum);
     match r {

--- a/examples/l2fwd-2link.rs
+++ b/examples/l2fwd-2link.rs
@@ -59,41 +59,45 @@ struct BufCustom {}
 #[derive(StructOpt, Debug)]
 #[structopt(name = "l2fwd-2link")]
 struct Opt {
+    /// Default buffer size
     #[structopt(long, default_value = "2048")]
     bufsize: usize,
 
+    /// Number of buffers
     #[structopt(long, default_value = "4096")]
     bufnum: usize,
 
-    #[structopt(long, default_value = "none")]
+    /// First link name
+    #[structopt(long)]
     link1_name: std::string::String,
 
+    /// First link channel
     #[structopt(long, default_value = "0")]
     link1_channel: usize,
 
-    #[structopt(long, default_value = "none")]
+    /// Second link name
+    #[structopt(long)]
     link2_name: std::string::String,
 
+    /// Second link channel
     #[structopt(long, default_value = "0")]
     link2_channel: usize,
 
+    /// Use HUGE TLB
     #[structopt(long)]
     huge_tlb: bool,
 
+    /// Zero copy mode
     #[structopt(long)]
     zero_copy: bool,
 
-    #[structopt(long)]
+    /// Copy mode
+    #[structopt(long, conflicts_with = "zero-copy")]
     copy: bool,
 }
 
 fn main() {
     let opt = Opt::from_args();
-
-    if opt.link1_name == "none" || opt.link2_name == "none" {
-        println!("Link name parameters must be passed");
-        return;
-    }
 
     let initial_fill_num = min(opt.bufnum / 2, RING_SIZE as usize);
 


### PR DESCRIPTION
This has mutliple benefits:

* The dependencies required for the examples no longer need to be
compiled when one is just using `afxdp-rs` as a library
* You can run the examples with `cargo run --release --example <example_name>`

I also made some slight changes to the `structopt` definition so that
`--link-name` is required (i.e. you longer need to check for it), and
`--copy`/`--zero-copy` now conflict with each other so you cannot use
them at the same time.